### PR TITLE
Fix: Unable to compile TypeScript

### DIFF
--- a/01/index.ts
+++ b/01/index.ts
@@ -1,7 +1,7 @@
 import { Observable } from 'rxjs';
 
 let n = 0;
-let id = 0;
+let id: NodeJS.Timeout = null;
 
 // Create an Observable from scratch
 const number$ = new Observable<number>(observer => {


### PR DESCRIPTION
Running `npx ts-node 01/index.ts` results in the following error: `Unable to compile TypeScript: 01/index.ts(8,3): error TS2322: Type 'Timeout' is not assignable to type 'number'`.

This is because [`setInterval()`](https://nodejs.org/api/timers.html#timers_setinterval_callback_delay_args) from Node.js returns a timeout object, not a number.
