### PR TITLE
Fix: create declaration file for module 'raf'

### DIFF
--- a/02/index.ts
+++ b/02/index.ts
@@ -1,4 +1,6 @@
-import { 
+/// <reference path="raf.d.ts" />
+
+import {
   Observable,
   SchedulerLike,
   animationFrameScheduler
@@ -23,5 +25,5 @@ const subscription = once(42, animationFrameScheduler)
     complete: () => console.log(`Complete!`)
   });
 
-// If we really don't want it to happen  
+// If we really don't want it to happen
 //subscription.unsubscribe();

--- a/02/raf.d.ts
+++ b/02/raf.d.ts
@@ -1,0 +1,1 @@
+declare module 'raf';


### PR DESCRIPTION
Running `npx ts-node 02/index.ts` results in the following error: 

"Unable to compile TypeScript: 02/index.ts(8,22): error TS7016: Could not find a declaration file for module 'raf'. 'rxjs-advent-2018/node_modules/raf/index.js' implicitly has an 'any' type. Try `npm install @types/raf` if it exists or add a new declaration (.d.ts) file containing `declare module 'raf';`".