### PR TITLE
Update scan callback to not use second argument

### DIFF
--- a/12/readme.md
+++ b/12/readme.md
@@ -83,8 +83,8 @@ import { scan, startWith } from 'rxjs/operators';
 const store$ = new Subject();
 const subscription = store$
   .pipe(
-    scan(reducer, initialState),
     startWith(initialState)
+    scan(reducer),
   )
   .subscribe({
     next: render


### PR DESCRIPTION
I just wanted to suggest an alternative way where `initialState` is only referenced once.

Running example to show that it works:
https://codesandbox.io/s/kw258120no

You can close this PR without comment if you want to keep your code as it is. Just wanted to throw a suggestion your way :-)